### PR TITLE
Fix: Invalid Site Key in Google API script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <meta name = "msapplication-TileColor" content = "#da532c">
     <meta name = "theme-color" content = "#ffffff">
 
-    <script src = "https://www.google.com/recaptcha/api.js?render = 6Lfahx0fAAAAAKBfUUCWCrdRplsy_EJG_-aan3yY"></script>
+    <script src = "https://www.google.com/recaptcha/api.js?render=6Lfahx0fAAAAAKBfUUCWCrdRplsy_EJG_-aan3yY"></script>
 
 </head>
 


### PR DESCRIPTION
Corrected script tag for Google reCAPTCHA v3 API. Resolved #36 